### PR TITLE
Further orbital map fixes and improvements

### DIFF
--- a/tgui/packages/tgui/components/OrbitalMapSvg.js
+++ b/tgui/packages/tgui/components/OrbitalMapSvg.js
@@ -104,15 +104,18 @@ export class OrbitalMapSvg extends Component {
       lockedZoomScale,
     } = this.props;
 
+    const stripesAngle = 40;
+    const factorX = Math.cos(stripesAngle*Math.PI/180);
+    const factorY = Math.sin(stripesAngle*Math.PI/180);
+
     return (
       <>
         <defs>
           <pattern id="interdictionRange" width={50 * lockedZoomScale}
             height={100 * lockedZoomScale}
             patternUnits="userSpaceOnUse"
-            patternTransform="rotate(40)"
-            x={scaledXOffset}
-            y={scaledYOffset}>
+            patternTransform={`rotate(${stripesAngle})`}
+            x={scaledXOffset*factorX+scaledYOffset*factorY}>
             <rect width={25 * lockedZoomScale}
               height={100 * lockedZoomScale}
               fill="rgba(64, 194, 86, 0.05)" />
@@ -125,9 +128,8 @@ export class OrbitalMapSvg extends Component {
           <pattern id="planetfill" width={50 * lockedZoomScale}
             height={100 * lockedZoomScale}
             patternUnits="userSpaceOnUse"
-            patternTransform="rotate(40)"
-            x={scaledXOffset}
-            y={scaledYOffset}>
+            patternTransform={`rotate(${stripesAngle})`}
+            x={scaledXOffset*factorX+scaledYOffset*factorY}>
             <rect width={25 * lockedZoomScale}
               height={100 * lockedZoomScale}
               fill="rgba(252, 166, 53, 0.2)" />

--- a/tgui/packages/tgui/interfaces/OrbitalMap.js
+++ b/tgui/packages/tgui/interfaces/OrbitalMap.js
@@ -2,7 +2,7 @@
 
 // Made by powerfulbacon
 
-import { Box, Button, Section, Table, DraggableClickableControl, Dropdown, Divider, NoticeBox, ProgressBar, ScrollableBox, OrbitalMapComponent, OrbitalMapSvg } from '../components';
+import { Box, Button, Section, Table, DraggableClickableControl, Dropdown, Divider, NoticeBox, ProgressBar, ScrollableBox, Flex, OrbitalMapComponent, OrbitalMapSvg } from '../components';
 import { useBackend, useLocalState } from '../backend';
 import { Window } from '../layouts';
 
@@ -69,109 +69,111 @@ export const OrbitalMap = (props, context) => {
       width={1136}
       height={770}>
       <Window.Content>
-        <Box class="OrbitalMap__radar" id="radar">
-          {interdictionTime ? (
-            <InterdictionDisplay
-              xOffset={dynamicXOffset}
-              yOffset={dynamicYOffset}
-              zoomScale={zoomScale}
-              setZoomScale={setZoomScale}
-              setXOffset={setXOffset}
-              setYOffset={setYOffset} />
-          ) : (
-            <OrbitalMapDisplay
-              dynamicXOffset={dynamicXOffset}
-              dynamicYOffset={dynamicYOffset}
-              isTracking={trackedBody !== map_objects[0].name}
-              zoomScale={zoomScale}
-              setZoomScale={setZoomScale}
-              setTrackedBody={setTrackedBody}
-              ourObject={ourObject} />
-          )}
-        </Box>
-        <Box class="OrbitalMap__panel">
-          <ScrollableBox overflowY="scroll" height="100%">
-            <Section title="Orbital Body Tracking">
-              <Box bold>
-                Tracking
-              </Box>
-              <Box mb={1}>
-                {trackedBody}
-              </Box>
-              <Box>
-                <b>
-                  X:&nbsp;
-                </b>
-                {trackedObject && trackedObject.position_x}
-              </Box>
-              <Box>
-                <b>
-                  Y:&nbsp;
-                </b>
-                {trackedObject && trackedObject.position_y}
-              </Box>
-              <Box>
-                <b>
-                  Velocity:&nbsp;
-                </b>
-                ({trackedObject && trackedObject.velocity_x}
-                , {trackedObject && trackedObject.velocity_y})
-              </Box>
-              <Box>
-                <b>
-                  Radius:&nbsp;
-                </b>
-                {trackedObject && trackedObject.radius} BSU
-              </Box>
+        <Flex height="100%">
+          <Flex.Item class="OrbitalMap__radar" grow id="radar">
+            {interdictionTime ? (
+              <InterdictionDisplay
+                xOffset={dynamicXOffset}
+                yOffset={dynamicYOffset}
+                zoomScale={zoomScale}
+                setZoomScale={setZoomScale}
+                setXOffset={setXOffset}
+                setYOffset={setYOffset} />
+            ) : (
+              <OrbitalMapDisplay
+                dynamicXOffset={dynamicXOffset}
+                dynamicYOffset={dynamicYOffset}
+                isTracking={trackedBody !== map_objects[0].name}
+                zoomScale={zoomScale}
+                setZoomScale={setZoomScale}
+                setTrackedBody={setTrackedBody}
+                ourObject={ourObject} />
+            )}
+          </Flex.Item>
+          <Flex.Item class="OrbitalMap__panel">
+            <ScrollableBox overflowY="scroll" height="100%">
+              <Section title="Orbital Body Tracking">
+                <Box bold>
+                  Tracking
+                </Box>
+                <Box mb={1}>
+                  {trackedBody}
+                </Box>
+                <Box>
+                  <b>
+                    X:&nbsp;
+                  </b>
+                  {trackedObject && trackedObject.position_x}
+                </Box>
+                <Box>
+                  <b>
+                    Y:&nbsp;
+                  </b>
+                  {trackedObject && trackedObject.position_y}
+                </Box>
+                <Box>
+                  <b>
+                    Velocity:&nbsp;
+                  </b>
+                  ({trackedObject && trackedObject.velocity_x}
+                  , {trackedObject && trackedObject.velocity_y})
+                </Box>
+                <Box>
+                  <b>
+                    Radius:&nbsp;
+                  </b>
+                  {trackedObject && trackedObject.radius} BSU
+                </Box>
+                <Divider />
+                <Dropdown
+                  selected={trackedBody}
+                  width="100%"
+                  color="grey"
+                  options={map_objects.sort((first,
+                    second) => { return second.priority - first.priority; })
+                    .map(map_object => (map_object.name))}
+                  onSelected={value => setTrackedBody(value)} />
+              </Section>
               <Divider />
-              <Dropdown
-                selected={trackedBody}
-                width="100%"
-                color="grey"
-                options={map_objects.sort((first,
-                  second) => { return second.priority - first.priority; })
-                  .map(map_object => (map_object.name))}
-                onSelected={value => setTrackedBody(value)} />
-            </Section>
-            <Divider />
-            <Section title="Flight Controls">
-              {(!thrust_alert) || (
-                <NoticeBox color="red">
-                  {thrust_alert}
-                </NoticeBox>
-              )}
-              {(!damage_alert) || (
-                <NoticeBox color="red">
-                  {damage_alert}
-                </NoticeBox>
-              )}
-              {recall_docking_port_id !== ""
-                ? <RecallControl />
-                : linkedToShuttle
-                  ? <ShuttleControls />
-                  : (canLaunch ? (
-                    <>
-                      <NoticeBox>
-                        Currently docked, awaiting launch order.
+              <Section title="Flight Controls">
+                {(!thrust_alert) || (
+                  <NoticeBox color="red">
+                    {thrust_alert}
+                  </NoticeBox>
+                )}
+                {(!damage_alert) || (
+                  <NoticeBox color="red">
+                    {damage_alert}
+                  </NoticeBox>
+                )}
+                {recall_docking_port_id !== ""
+                  ? <RecallControl />
+                  : linkedToShuttle
+                    ? <ShuttleControls />
+                    : (canLaunch ? (
+                      <>
+                        <NoticeBox>
+                          Currently docked, awaiting launch order.
+                        </NoticeBox>
+                        <Button
+                          content="INITIATE LAUNCH"
+                          textAlign="center"
+                          fontSize="30px"
+                          icon="rocket"
+                          width="100%"
+                          height="50px"
+                          onClick={() => act('launch')} />
+                      </>
+                    ) : (
+                      <NoticeBox
+                        color="red">
+                        Not linked to a shuttle.
                       </NoticeBox>
-                      <Button
-                        content="INITIATE LAUNCH"
-                        textAlign="center"
-                        fontSize="30px"
-                        icon="rocket"
-                        width="100%"
-                        height="50px"
-                        onClick={() => act('launch')} />
-                    </>
-                  ) : (
-                    <NoticeBox
-                      color="red">
-                      Not linked to a shuttle.
-                    </NoticeBox>
-                  ))}
-            </Section>
-          </ScrollableBox>
-        </Box>
+                    ))}
+              </Section>
+            </ScrollableBox>
+          </Flex.Item>
+        </Flex>
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/OrbitalMap.js
+++ b/tgui/packages/tgui/interfaces/OrbitalMap.js
@@ -68,7 +68,7 @@ export const OrbitalMap = (props, context) => {
     <Window
       width={1136}
       height={770}>
-      <Window.Content>
+      <Window.Content fitted>
         <Flex height="100%">
           <Flex.Item class="OrbitalMap__radar" grow id="radar">
             {interdictionTime ? (
@@ -91,7 +91,7 @@ export const OrbitalMap = (props, context) => {
             )}
           </Flex.Item>
           <Flex.Item class="OrbitalMap__panel">
-            <ScrollableBox overflowY="scroll" height="100%">
+            <Section fill scrollable>
               <Section title="Orbital Body Tracking">
                 <Box bold>
                   Tracking
@@ -171,7 +171,7 @@ export const OrbitalMap = (props, context) => {
                       </NoticeBox>
                     ))}
               </Section>
-            </ScrollableBox>
+            </Section>
           </Flex.Item>
         </Flex>
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/OrbitalMap.js
+++ b/tgui/packages/tgui/interfaces/OrbitalMap.js
@@ -2,7 +2,7 @@
 
 // Made by powerfulbacon
 
-import { Box, Button, Section, Table, DraggableClickableControl, Dropdown, Divider, NoticeBox, ProgressBar, Fragment, ScrollableBox, OrbitalMapComponent, OrbitalMapSvg } from '../components';
+import { Box, Button, Section, Table, DraggableClickableControl, Dropdown, Divider, NoticeBox, ProgressBar, ScrollableBox, OrbitalMapComponent, OrbitalMapSvg } from '../components';
 import { useBackend, useLocalState } from '../backend';
 import { Window } from '../layouts';
 
@@ -67,11 +67,9 @@ export const OrbitalMap = (props, context) => {
   return (
     <Window
       width={1136}
-      height={770}
-      resizable
-      overflowY="hidden">
-      <Window.Content overflowY="hidden">
-        <div class="OrbitalMap__radar" id="radar">
+      height={770}>
+      <Window.Content>
+        <Box class="OrbitalMap__radar" id="radar">
           {interdictionTime ? (
             <InterdictionDisplay
               xOffset={dynamicXOffset}
@@ -90,8 +88,8 @@ export const OrbitalMap = (props, context) => {
               setTrackedBody={setTrackedBody}
               ourObject={ourObject} />
           )}
-        </div>
-        <div class="OrbitalMap__panel">
+        </Box>
+        <Box class="OrbitalMap__panel">
           <ScrollableBox overflowY="scroll" height="100%">
             <Section title="Orbital Body Tracking">
               <Box bold>
@@ -173,7 +171,7 @@ export const OrbitalMap = (props, context) => {
                   ))}
             </Section>
           </ScrollableBox>
-        </div>
+        </Box>
       </Window.Content>
     </Window>
   );
@@ -206,7 +204,7 @@ export const InterdictionDisplay = (props, context) => {
   } = data;
 
   return (
-    <Fragment>
+    <>
       <NoticeBox
         position="absolute"
         color="red">
@@ -332,7 +330,7 @@ export const InterdictionDisplay = (props, context) => {
           </DraggableClickableControl>
         )}
       </DraggableClickableControl>
-    </Fragment>
+    </>
   );
 
 };
@@ -370,7 +368,7 @@ export const OrbitalMapDisplay = (props, context) => {
   } = data;
 
   return (
-    <Fragment>
+    <>
       <Button
         position="absolute"
         icon="search-plus"
@@ -469,7 +467,7 @@ export const OrbitalMapDisplay = (props, context) => {
           </OrbitalMapSvg>
         )}
       </OrbitalMapComponent>
-    </Fragment>
+    </>
   );
 
 };

--- a/tgui/packages/tgui/styles/interfaces/OrbitalMap.scss
+++ b/tgui/packages/tgui/styles/interfaces/OrbitalMap.scss
@@ -1,11 +1,4 @@
 .OrbitalMap__radar {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 400px;
-  overflow-x: hidden;
-  overflow-y: hidden;
 }
 
 .OrbitalMap__radar * {
@@ -13,10 +6,5 @@
 }
 
 .OrbitalMap__panel {
-  position: absolute;
-  right: 0%;
   width: 400px;
-  height: 100%;
-  border-left: 5px;
-  border-right: 5px;
 }

--- a/tgui/packages/tgui/styles/interfaces/OrbitalMap.scss
+++ b/tgui/packages/tgui/styles/interfaces/OrbitalMap.scss
@@ -1,4 +1,6 @@
 .OrbitalMap__radar {
+  position: relative;
+  overflow: hidden;
 }
 
 .OrbitalMap__radar * {

--- a/tgui/packages/tgui/styles/interfaces/OrbitalMap.scss
+++ b/tgui/packages/tgui/styles/interfaces/OrbitalMap.scss
@@ -3,7 +3,7 @@
   top: 0;
   left: 0;
   bottom: 0;
-  width: calc(100% - 400px);
+  right: 400px;
   overflow-x: hidden;
   overflow-y: hidden;
 }

--- a/tgui/packages/tgui/styles/interfaces/OrbitalMap.scss
+++ b/tgui/packages/tgui/styles/interfaces/OrbitalMap.scss
@@ -8,6 +8,10 @@
   overflow-y: hidden;
 }
 
+.OrbitalMap__radar * {
+  overflow: hidden;
+}
+
 .OrbitalMap__panel {
   position: absolute;
   right: 0%;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Hide overflow on all children of `.OrbitalMap__radar`, **including all nested children.**
- Convert the absolutely positioned `div` elements of the map and side panel to instead use a `Flex`.
- Convert the `ScrollableBox` of the sidepanel to a scrollable `Section`.
- Set the `Window.Content` to be `fitted`, removing the empty space around the interface.
- Clean up some unnecessary, redundant and meaningless props.
- Correct the offset of stripes on some orbital bodies, like planets. The offset is applied before the rotation, so the offset on the position needs to account for the rotation ahead of time.

The interface will no longer arbitrarily scroll offscreen - it is now properly fitted to the window, additionally eliminating the empty space around it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Testing Photographs and Procedure
<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->
<details>



<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/6917698/148957961-14fe5375-fc92-4168-aba9-c8f796320da2.png)

</details>

## Changelog

Don't you dare somehow generate a changelog for this on your PR.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
