### PR TITLE
Adds ship-based access requirements

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -154,6 +154,7 @@ SUBSYSTEM_DEF(shuttle)
 	emergencyNoRecall = FALSE
 
 /datum/controller/subsystem/shuttle/proc/getShuttle(id)
+	RETURN_TYPE(/obj/docking_port/mobile)
 	for(var/obj/docking_port/mobile/M in mobile)
 		if(M.id == id)
 			return M

--- a/code/game/machinery/airlock_cycle_control.dm
+++ b/code/game/machinery/airlock_cycle_control.dm
@@ -126,11 +126,6 @@
 	scan_on_late_init = mapload
 	if(mapload && (. != INITIALIZE_HINT_QDEL))
 		return INITIALIZE_HINT_LATELOAD
-	if(!mapload)
-		var/area/A = get_area(src)
-		if(istype(A,/area/shuttle))
-			var/area/shuttle/AS = A
-			req_ship_access = AS.mobile_port?.id
 
 /obj/machinery/advanced_airlock_controller/LateInitialize(mapload)
 	. = ..()

--- a/code/game/machinery/airlock_cycle_control.dm
+++ b/code/game/machinery/airlock_cycle_control.dm
@@ -826,6 +826,11 @@
 /obj/machinery/door/airlock/Initialize(mapload)
 	. = ..()
 	update_aac_docked()
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
+
 /obj/machinery/door/airlock/Destroy()
 	var/turf/T = get_turf(src)
 	. = ..()

--- a/code/game/machinery/airlock_cycle_control.dm
+++ b/code/game/machinery/airlock_cycle_control.dm
@@ -126,6 +126,11 @@
 	scan_on_late_init = mapload
 	if(mapload && (. != INITIALIZE_HINT_QDEL))
 		return INITIALIZE_HINT_LATELOAD
+	if(!mapload)
+		var/area/A = get_area(src)
+		if(istype(A,/area/shuttle))
+			var/area/shuttle/AS = A
+			req_ship_access = AS.mobile_port?.id
 
 /obj/machinery/advanced_airlock_controller/LateInitialize(mapload)
 	. = ..()
@@ -137,6 +142,10 @@
 			var/obj/machinery/door/airlock/airlock = A
 			if(airlock.density && (cyclestate == AIRLOCK_CYCLESTATE_CLOSED || (airlocks[A] && cyclestate == AIRLOCK_CYCLESTATE_INOPEN) || (!airlocks[A] && cyclestate == AIRLOCK_CYCLESTATE_OUTOPEN)))
 				airlock.bolt()
+
+/obj/machinery/advanced_airlock_controller/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	..()
+	req_ship_access = port.id
 
 /obj/machinery/advanced_airlock_controller/update_icon(use_hash = FALSE)
 	var/turf/location = get_turf(src)
@@ -826,10 +835,6 @@
 /obj/machinery/door/airlock/Initialize(mapload)
 	. = ..()
 	update_aac_docked()
-	var/area/A = get_area(src)
-	if(istype(A, /area/shuttle))
-		var/area/shuttle/AS = A
-		req_ship_access = AS.mobile_port?.id
 
 /obj/machinery/door/airlock/Destroy()
 	var/turf/T = get_turf(src)

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -41,7 +41,10 @@
 		else
 			board.one_access = 1
 			board.accesses = req_one_access
-
+		var/area/A = get_area(src)
+		if(istype(A, /area/shuttle))
+			var/area/shuttle/AS = A
+			req_ship_access = AS.mobile_port?.id
 
 /obj/machinery/button/update_icon()
 	cut_overlays()

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -48,9 +48,9 @@
 			var/area/shuttle/AS = A
 			req_ship_access = AS.mobile_port?.id
 
-/obj/machinery/advanced_airlock_controller/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+/obj/machinery/button/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
 	..()
-	if(req_accss.len || req_one_access.len)
+	if(req_access.len || req_one_access.len)
 		req_ship_access = port.id
 
 /obj/machinery/button/update_icon()

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -42,12 +42,6 @@
 			board.one_access = 1
 			board.accesses = req_one_access
 
-	if(!mapload)
-		var/area/A = get_area(src)
-		if(istype(A, /area/shuttle))
-			var/area/shuttle/AS = A
-			req_ship_access = AS.mobile_port?.id
-
 /obj/machinery/button/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
 	..()
 	if(req_access.len || req_one_access.len)

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -41,10 +41,17 @@
 		else
 			board.one_access = 1
 			board.accesses = req_one_access
+
+	if(!mapload)
 		var/area/A = get_area(src)
 		if(istype(A, /area/shuttle))
 			var/area/shuttle/AS = A
 			req_ship_access = AS.mobile_port?.id
+
+/obj/machinery/advanced_airlock_controller/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	..()
+	if(req_accss.len || req_one_access.len)
+		req_ship_access = port.id
 
 /obj/machinery/button/update_icon()
 	cut_overlays()

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -21,7 +21,7 @@
 			var/area/shuttle/AS = A
 			req_ship_access = AS.mobile_port?.id
 
-/obj/machinery/advanced_airlock_controller/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+/obj/machinery/computer/pod/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
 	..()
 	req_ship_access = port.id
 

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -15,11 +15,15 @@
 		if(M.id == id)
 			connected = M
 
-	var/area/A = get_area(src)
-	if(istype(A, /area/shuttle))
-		var/area/shuttle/AS = A
-		req_ship_access = AS.mobile_port?.id
+	if(!mapload)
+		var/area/A = get_area(src)
+		if(istype(A, /area/shuttle))
+			var/area/shuttle/AS = A
+			req_ship_access = AS.mobile_port?.id
 
+/obj/machinery/advanced_airlock_controller/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	..()
+	req_ship_access = port.id
 
 /obj/machinery/computer/pod/proc/alarm()
 	if(machine_stat & (NOPOWER|BROKEN))

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -15,6 +15,11 @@
 		if(M.id == id)
 			connected = M
 
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
+
 
 /obj/machinery/computer/pod/proc/alarm()
 	if(machine_stat & (NOPOWER|BROKEN))

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -17,6 +17,10 @@
 	radio.subspace_transmission = TRUE
 	radio.canhear_range = 0
 	radio.recalculateChannels()
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
 
 /obj/machinery/computer/robotics/Destroy()
 	QDEL_NULL(radio)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -17,10 +17,11 @@
 	radio.subspace_transmission = TRUE
 	radio.canhear_range = 0
 	radio.recalculateChannels()
-	var/area/A = get_area(src)
-	if(istype(A, /area/shuttle))
-		var/area/shuttle/AS = A
-		req_ship_access = AS.mobile_port?.id
+	if(!mapload)
+		var/area/A = get_area(src)
+		if(istype(A, /area/shuttle))
+			var/area/shuttle/AS = A
+			req_ship_access = AS.mobile_port?.id
 
 /obj/machinery/computer/robotics/Destroy()
 	QDEL_NULL(radio)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -68,10 +68,15 @@
 	explosion_block = EXPLOSION_BLOCK_PROC
 	if(red_alert_access)
 		RegisterSignal(SSdcs, COMSIG_GLOB_SECURITY_ALERT_CHANGE, PROC_REF(handle_alert))
-	var/area/A = get_area(src)
-	if(istype(A, /area/shuttle))
-		var/area/shuttle/AS = A
-		req_ship_access = AS.mobile_port?.id
+	if(!mapload)
+		var/area/A = get_area(src)
+		if(istype(A, /area/shuttle))
+			var/area/shuttle/AS = A
+			req_ship_access = AS.mobile_port?.id
+
+/obj/machinery/advanced_airlock_controller/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	..()
+	req_ship_access = port.id
 
 /obj/machinery/door/proc/handle_alert(datum/source, new_alert)
 	SIGNAL_HANDLER

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -68,6 +68,10 @@
 	explosion_block = EXPLOSION_BLOCK_PROC
 	if(red_alert_access)
 		RegisterSignal(SSdcs, COMSIG_GLOB_SECURITY_ALERT_CHANGE, PROC_REF(handle_alert))
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
 
 /obj/machinery/door/proc/handle_alert(datum/source, new_alert)
 	SIGNAL_HANDLER

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -74,7 +74,7 @@
 			var/area/shuttle/AS = A
 			req_ship_access = AS.mobile_port?.id
 
-/obj/machinery/advanced_airlock_controller/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+/obj/machinery/door/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
 	..()
 	req_ship_access = port.id
 

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -35,10 +35,15 @@
 		GLOB.deliverybeacons += src
 		GLOB.deliverybeacontags += location
 
-	var/area/A = get_area(src)
-	if(istype(A, /area/shuttle))
-		var/area/shuttle/AS = A
-		req_ship_access = AS.mobile_port?.id
+	if(!mapload)
+		var/area/A = get_area(src)
+		if(istype(A, /area/shuttle))
+			var/area/shuttle/AS = A
+			req_ship_access = AS.mobile_port?.id
+
+/obj/machinery/advanced_airlock_controller/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	..()
+	req_ship_access = port.id
 
 /obj/machinery/navbeacon/Destroy()
 	if (GLOB.navbeacons["[z]"])

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -35,6 +35,11 @@
 		GLOB.deliverybeacons += src
 		GLOB.deliverybeacontags += location
 
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
+
 /obj/machinery/navbeacon/Destroy()
 	if (GLOB.navbeacons["[z]"])
 		GLOB.navbeacons["[z]"] -= src //Remove from beacon list, if in one.

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -41,7 +41,7 @@
 			var/area/shuttle/AS = A
 			req_ship_access = AS.mobile_port?.id
 
-/obj/machinery/advanced_airlock_controller/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+/obj/machinery/navbeacon/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
 	..()
 	req_ship_access = port.id
 

--- a/code/game/machinery/scan_gate.dm
+++ b/code/game/machinery/scan_gate.dm
@@ -6,6 +6,7 @@
 #define SCANGATE_WANTED			"Wanted"
 #define SCANGATE_SPECIES		"Species"
 #define SCANGATE_NUTRITION		"Nutrition"
+#define SCANGATE_SHIP			"Ship"
 
 #define SCANGATE_HUMAN			"human"
 #define SCANGATE_LIZARD			"lizard"
@@ -77,6 +78,7 @@
 			if(allowed(user))
 				locked = FALSE
 				req_access = list()
+				req_ship_access = null
 				to_chat(user, "<span class='notice'>You unlock [src].</span>")
 				//Update to viewers
 				ui_update()
@@ -84,6 +86,7 @@
 			to_chat(user, "<span class='notice'>You lock [src] with [W].</span>")
 			var/list/access = W.GetAccess()
 			req_access = access
+			req_ship_access = W.GetShipAccess()
 			locked = TRUE
 			//Update to viewers
 			ui_update()
@@ -167,6 +170,11 @@
 				if(H.nutrition <= detect_nutrition && detect_nutrition == NUTRITION_LEVEL_STARVING)
 					beep = TRUE
 				if(H.nutrition >= detect_nutrition && detect_nutrition == NUTRITION_LEVEL_FAT)
+					beep = TRUE
+		if(SCANGATE_SHIP)
+			if(M.get_idcard())
+				var/obj/item/card/id/ID = M.get_idcard()
+				if(ID.GetShipAccess() == req_ship_access)
 					beep = TRUE
 
 	if(reverse)

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -57,6 +57,11 @@
 
 /obj/item/wallframe/proc/after_attach(var/obj/O)
 	transfer_fingerprints_to(O)
+	if(O.req_access || O.req_access_txt)
+		var/area/A = get_area(src)
+		if(istype(A, /area/shuttle))
+			var/area/shuttle/AS = A
+			O.req_ship_access = AS.mobile_port?.id
 
 /obj/item/wallframe/attackby(obj/item/W, mob/user, params)
 	..()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -122,13 +122,12 @@
 
 /obj/item/card/id/Initialize(mapload)
 	. = ..()
-	if(mapload)
-		if(access_txt)
+	if(mapload && access_txt)
 			access = text2access(access_txt)
-		var/area/A = get_area(src)
-		if(istype(A, /area/shuttle))
-			var/area/shuttle/AS = A
-			ship_port = AS.mobile_port?.id
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		ship_port = AS.mobile_port?.id
 
 /obj/item/card/id/Destroy()
 	if (registered_account)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -110,6 +110,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100, "stamina" = 0)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	var/list/access = list()
+	var/ship_port // The ship this card has access to
 	var/registered_name// The name registered_name on the card
 	var/assignment
 	var/hud_state = JOB_HUD_UNKNOWN
@@ -121,8 +122,13 @@
 
 /obj/item/card/id/Initialize(mapload)
 	. = ..()
-	if(mapload && access_txt)
-		access = text2access(access_txt)
+	if(mapload)
+		if(access_txt)
+			access = text2access(access_txt)
+		var/area/A = get_area(src)
+		if(istype(A, /area/shuttle))
+			var/area/shuttle/AS = A
+			ship_port = AS.mobile_port?.id
 
 /obj/item/card/id/Destroy()
 	if (registered_account)
@@ -338,6 +344,9 @@
 
 /obj/item/card/id/RemoveID()
 	return src
+
+/obj/item/card/id/GetShipAccess()
+	return ship_port
 
 /*
 Usage:
@@ -779,6 +788,9 @@ update_label("John Doe", "Clowny")
 
 /obj/item/card/id/paper/GetAccess()
 	return list()
+
+/obj/item/card/id/paper/GetShipAccess()
+	return
 
 /obj/item/card/id/paper/update_label(newname, newjob)
 	if(newname || newjob)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -123,7 +123,7 @@
 /obj/item/card/id/Initialize(mapload)
 	. = ..()
 	if(mapload && access_txt)
-			access = text2access(access_txt)
+		access = text2access(access_txt)
 	var/area/A = get_area(src)
 	if(istype(A, /area/shuttle))
 		var/area/shuttle/AS = A

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -18,6 +18,9 @@
 		var/area/shuttle/AS = A
 		req_ship_access = AS.mobile_port?.id
 
+/obj/item/storage/lockbox/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	..()
+	req_ship_access = port.id
 
 /obj/item/storage/lockbox/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -11,6 +11,14 @@
 	var/open = FALSE
 	base_icon_state = "lockbox"
 
+/obj/item/storage/lockbox/Initialize(mapload)
+	. = ..()
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
+
+
 /obj/item/storage/lockbox/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -94,6 +94,9 @@
 	else
 		return ..()
 
+/obj/item/storage/wallet/GetShipAccess()
+	return front_id?.GetShipAccess()
+
 /obj/item/storage/wallet/random
 	icon_state = "random_wallet"
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -34,6 +34,7 @@
 	var/req_access_txt = "0"
 	var/list/req_one_access
 	var/req_one_access_txt = "0"
+	var/req_ship_access
 	/// Custom fire overlay icon
 	var/custom_fire_overlay
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -47,14 +47,19 @@
 	if(mapload)		// if closed, any item at the crate's loc is put in the contents
 		if(!opened)
 			addtimer(CALLBACK(src, PROC_REF(take_contents)), 0)
-		if(secure)
-			var/area/A = get_area(src)
-			if(istype(A, /area/shuttle))
-				var/area/shuttle/AS = A
-				req_ship_access = AS.mobile_port?.id
+	if(secure && !mapload)
+		var/area/A = get_area(src)
+		if(istype(A, /area/shuttle))
+			var/area/shuttle/AS = A
+			req_ship_access = AS.mobile_port?.id
 	. = ..()
 	update_icon()
 	PopulateContents()
+
+/obj/structure/closet/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	..()
+	if(secure)
+		req_ship_access = port.id
 
 //USE THIS TO FILL IT, NOT INITIALIZE OR NEW
 /obj/structure/closet/proc/PopulateContents()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -42,9 +42,16 @@
 	var/door_anim_angle = 136
 	var/door_hinge = -6.5
 	var/door_anim_time = 2.0 // set to 0 to make the door not animate at all
+
 /obj/structure/closet/Initialize(mapload)
-	if(mapload && !opened)		// if closed, any item at the crate's loc is put in the contents
-		addtimer(CALLBACK(src, PROC_REF(take_contents)), 0)
+	if(mapload)		// if closed, any item at the crate's loc is put in the contents
+		if(!opened)
+			addtimer(CALLBACK(src, PROC_REF(take_contents)), 0)
+		if(secure)
+			var/area/A = get_area(src)
+			if(istype(A, /area/shuttle))
+				var/area/shuttle/AS = A
+				req_ship_access = AS.mobile_port?.id
 	. = ..()
 	update_icon()
 	PopulateContents()

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -41,10 +41,9 @@
 		showpiece = new start_showpiece_type (src)
 	update_icon()
 
-	var/area/A = get_area(src)
-	if(istype(A, /area/shuttle))
-		var/area/shuttle/AS = A
-		req_ship_access = AS.mobile_port?.id
+/obj/structure/displaycase/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	..()
+	req_ship_access = port.id
 
 /obj/structure/displaycase/vv_edit_var(vname, vval)
 	. = ..()

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -41,6 +41,11 @@
 		showpiece = new start_showpiece_type (src)
 	update_icon()
 
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
+
 /obj/structure/displaycase/vv_edit_var(vname, vval)
 	. = ..()
 	if(vname in list(NAMEOF(src, open), NAMEOF(src, showpiece), NAMEOF(src, custom_glass_overlay)))

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -211,6 +211,11 @@
 	set_frequency(frequency)
 	GLOB.zclear_atoms += src
 
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
+
 /obj/machinery/airalarm/Destroy()
 	SSradio.remove_object(src, frequency)
 	qdel(wires)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -211,10 +211,9 @@
 	set_frequency(frequency)
 	GLOB.zclear_atoms += src
 
-	var/area/A = get_area(src)
-	if(istype(A, /area/shuttle))
-		var/area/shuttle/AS = A
-		req_ship_access = AS.mobile_port?.id
+/obj/machinery/airalarm/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	..()
+	req_ship_access = port.id
 
 /obj/machinery/airalarm/Destroy()
 	SSradio.remove_object(src, frequency)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -56,13 +56,10 @@
 		"caution" = /obj/machinery/portable_atmospherics/canister,
 	)
 
-/obj/machinery/portable_atmospherics/canister/Initialize(mapload)
-	. = ..()
-	if(mapload)
-		var/area/A = get_area(src)
-		if(istype(A, /area/shuttle))
-			var/area/shuttle/AS = A
-			req_ship_access = AS.mobile_port?.id
+/obj/machinery/portable_atmospherics/canister/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	..()
+	if(restricted)
+		req_ship_access = port.id
 
 /obj/machinery/portable_atmospherics/canister/interact(mob/user)
 	if(!allowed(user))

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -56,6 +56,14 @@
 		"caution" = /obj/machinery/portable_atmospherics/canister,
 	)
 
+/obj/machinery/portable_atmospherics/canister/Initialize(mapload)
+	. = ..()
+	if(mapload)
+		var/area/A = get_area(src)
+		if(istype(A, /area/shuttle))
+			var/area/shuttle/AS = A
+			req_ship_access = AS.mobile_port?.id
+
 /obj/machinery/portable_atmospherics/canister/interact(mob/user)
 	if(!allowed(user))
 		to_chat(user, "<span class='warning'>Error - Unauthorized User</span>")

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -421,6 +421,8 @@
 /obj/proc/check_access_ship(obj/item/I)
 	if(!req_ship_access)
 		return TRUE
+	else if(!I)
+		return FALSE
 	else if(req_ship_access != I.GetShipAccess())
 		return FALSE
 

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -3,7 +3,7 @@
 ///Note that this will return FALSE when passed null, unless the door doesn't require any access.
 /obj/proc/allowed(mob/M)
 	//check if it doesn't require any access at all
-	if(src.check_access(null))
+	if(src.check_access(null) && src.check_access_ship(null))
 		return TRUE
 	if(issilicon(M))
 		var/mob/living/silicon/S = M
@@ -16,16 +16,16 @@
 	else if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		//if they are holding or wearing a card that has access, that works
-		if(check_access(H.get_active_held_item()) || src.check_access(H.wear_id))
+		if((check_access(H.get_active_held_item()) || src.check_access(H.wear_id)) && (check_access_ship(H.get_active_held_item()) || src.check_access_ship(H.wear_id)))
 			return TRUE
 	else if(ismonkey(M) || isalienadult(M))
 		var/mob/living/carbon/george = M
 		//they can only hold things :(
-		if(check_access(george.get_active_held_item()))
+		if(check_access(george.get_active_held_item()) && check_access_ship(george.get_active_held_item()))
 			return TRUE
 	else if(isanimal(M))
 		var/mob/living/simple_animal/A = M
-		if(check_access(A.get_active_held_item()) || check_access(A.access_card))
+		if((check_access(A.get_active_held_item()) || check_access(A.access_card)) && (check_access_ship(A.get_active_held_item()) || check_access_ship(A.access_card)))
 			return TRUE
 	return FALSE
 
@@ -413,3 +413,16 @@
 	if(I_hud)
 		return I_hud
 	return "unknown"
+
+/*
+	Access for different ships using supercruise
+*/
+
+/obj/proc/check_access_ship(obj/item/I)
+	if(!req_ship_access)
+		return TRUE
+	else if(req_ship_access != I.GetShipAccess())
+		return FALSE
+
+/obj/item/proc/GetShipAccess()
+	return null

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -425,6 +425,7 @@
 		return FALSE
 	else if(req_ship_access != I.GetShipAccess())
 		return FALSE
+	return TRUE
 
 /obj/item/proc/GetShipAccess()
 	return null

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -187,7 +187,7 @@
 	RegisterSignal(src, COMSIG_ATOM_ON_EMAG, PROC_REF(on_emag))
 	RegisterSignal(src, COMSIG_ATOM_SHOULD_EMAG, PROC_REF(should_emag))
 
-/obj/machinery/advanced_airlock_controller/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+/obj/living/simple_animal/bot/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
 	..()
 	access_card.ship_port = port.id
 	bot_core.req_ship_access = port.id

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -187,7 +187,7 @@
 	RegisterSignal(src, COMSIG_ATOM_ON_EMAG, PROC_REF(on_emag))
 	RegisterSignal(src, COMSIG_ATOM_SHOULD_EMAG, PROC_REF(should_emag))
 
-/obj/living/simple_animal/bot/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+/mob/living/simple_animal/bot/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
 	..()
 	access_card.ship_port = port.id
 	bot_core.req_ship_access = port.id

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -162,11 +162,12 @@
 
 	bot_core = new bot_core_type(src)
 
-	var/area/A = get_area(src)
-	if(istype(A, /area/shuttle))
-		var/area/shuttle/AS = A
-		bot_core.req_ship_access = AS.mobile_port?.id
-	access_card.ship_port = bot_core.req_ship_access
+	if(!mapload)
+		var/area/A = get_area(src)
+		if(istype(A, /area/shuttle))
+			var/area/shuttle/AS = A
+			bot_core.req_ship_access = AS.mobile_port?.id
+			access_card.ship_port = bot_core.req_ship_access
 
 	//Adds bot to the diagnostic HUD system
 	prepare_huds()
@@ -185,6 +186,11 @@
 		path_hud.add_hud_to(src)
 	RegisterSignal(src, COMSIG_ATOM_ON_EMAG, PROC_REF(on_emag))
 	RegisterSignal(src, COMSIG_ATOM_SHOULD_EMAG, PROC_REF(should_emag))
+
+/obj/machinery/advanced_airlock_controller/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	..()
+	access_card.ship_port = port.id
+	bot_core.req_ship_access = port.id
 
 /mob/living/simple_animal/bot/update_mobility()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -162,6 +162,12 @@
 
 	bot_core = new bot_core_type(src)
 
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		bot_core.req_ship_access = AS.mobile_port?.id
+	access_card.ship_port = bot_core.req_ship_access
+
 	//Adds bot to the diagnostic HUD system
 	prepare_huds()
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -191,6 +191,11 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		return card_slot.GetAccess()
 	return ..()
 
+/obj/item/modular_computer/GetShipAccess()
+	var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
+	if(card_slot)
+		return card_slot.GetShipAccess()
+
 /obj/item/modular_computer/GetID()
 	var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
 	if(card_slot)

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -71,7 +71,7 @@
 	if(!target_dept && (ACCESS_CHANGE_IDS in id_card.access))
 		minor = FALSE
 		authenticated = TRUE
-		if(ACCESS_CAPTAIN in id_card.access && id_card.ship_port)
+		if((ACCESS_CAPTAIN in id_card.access) && id_card.ship_port)
 			ship_port = id_card.GetShipAccess()
 		update_static_data(user)
 		return TRUE

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -29,6 +29,9 @@
 		total_access |= card_slot2.stored_card.GetAccess()
 	return total_access
 
+/obj/item/computer_hardware/card_slot/GetShipAccess()
+	return stored_card?.GetShipAccess()
+
 /obj/item/computer_hardware/card_slot/GetID()
 	if(stored_card)
 		return stored_card

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -89,7 +89,7 @@
 	///used for the Blackout malf module
 	var/overload = 1
 	///used for counting how many times it has been hit, used for Aliens at the moment
-	var/beenhit = 0 
+	var/beenhit = 0
 	///Reference to the shunted ai inside
 	var/mob/living/silicon/ai/occupier = null
 	///Is there an AI being transferred out of us?
@@ -118,9 +118,9 @@
 	var/obj/machinery/computer/apc_control/remote_control = null
 
 	//Clockcult - Has the reward for converting an APC been given?
-	var/clock_cog_rewarded = FALSE	
+	var/clock_cog_rewarded = FALSE
 	//Clockcult - The integration cog inserted inside of us
-	var/integration_cog = null		
+	var/integration_cog = null
 
 /obj/machinery/power/apc/New(turf/loc, var/ndir, var/building=0)
 	if (!req_access)
@@ -227,6 +227,10 @@
 			stack_trace("Bad areastring path for [src], [areastring]")
 	else if(isarea(A) && areastring == null)
 		area = A
+
+	if(istype(area, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
 
 	if(auto_name)
 		name = "\improper [get_area_name(area, TRUE)] APC"

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -228,9 +228,6 @@
 	else if(isarea(A) && areastring == null)
 		area = A
 
-	if(istype(area, /area/shuttle))
-		var/area/shuttle/AS = A
-		req_ship_access = AS.mobile_port?.id
 
 	if(auto_name)
 		name = "\improper [get_area_name(area, TRUE)] APC"
@@ -240,6 +237,10 @@
 	make_terminal()
 
 	addtimer(CALLBACK(src, PROC_REF(update)), 5)
+
+/obj/machinery/power/apc/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	..()
+	req_ship_access = port.id
 
 /obj/machinery/power/apc/examine(mob/user)
 	. = ..()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -68,6 +68,10 @@
 	sparks = new
 	sparks.attach(src)
 	sparks.set_up(5, TRUE, src)
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
 
 /obj/machinery/power/emitter/ComponentInitialize()
 	. = ..()
@@ -458,6 +462,10 @@
 /obj/item/turret_control/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
 
 /obj/item/turret_control/afterattack(atom/targeted_atom, mob/user, proxflag, clickparams)
 	. = ..()

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -52,6 +52,11 @@
 	// The +10 is so the sparks work
 	RefreshParts()
 
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
+
 /obj/machinery/rnd/server/Destroy()
 	SSresearch.servers -= src
 	return ..()

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -28,16 +28,15 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 /obj/machinery/keycard_auth/Initialize(mapload)
 	. = ..()
 	ev = GLOB.keycard_events.addEvent("triggerEvent", CALLBACK(src, PROC_REF(triggerEvent)))
-	var/area/A = get_area(src)
-	if(istype(A, /area/shuttle))
-		var/area/shuttle/AS = A
-		req_ship_access = AS.mobile_port?.id
+
+/obj/machinery/keycard_auth/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	..()
+	req_ship_access = port.id
 
 /obj/machinery/keycard_auth/Destroy()
 	GLOB.keycard_events.clearEvent("triggerEvent", ev)
 	QDEL_NULL(ev)
 	return ..()
-
 
 /obj/machinery/keycard_auth/ui_state(mob/user)
 	return GLOB.physical_state

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -28,6 +28,10 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 /obj/machinery/keycard_auth/Initialize(mapload)
 	. = ..()
 	ev = GLOB.keycard_events.addEvent("triggerEvent", CALLBACK(src, PROC_REF(triggerEvent)))
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
 
 /obj/machinery/keycard_auth/Destroy()
 	GLOB.keycard_events.clearEvent("triggerEvent", ev)

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -70,10 +70,6 @@
 	unbolted = add_output_port("Unbolted", PORT_TYPE_SIGNAL)
 	user_port = add_output_port("User", PORT_TYPE_ATOM)
 	trigger_port = add_output_port("Triggered", PORT_TYPE_SIGNAL)
-	var/area/A = get_area(src)
-	if(istype(A, /area/shuttle))
-		var/area/shuttle/AS = A
-		req_ship_access = AS.mobile_port?.id
 
 /obj/item/circuit_component/airlock/Destroy()
 	bolt = null

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -14,6 +14,9 @@
 /obj/machinery/door/airlock/shell/check_access(obj/item/I)
 	return FALSE
 
+/obj/machinery/door/airlock/shell/check_access_ship(obj/item/I)
+	return FALSE
+
 /obj/item/circuit_component/airlock
 	display_name = "Airlock"
 	display_desc = "The general interface with an airlock. Includes general statuses of the airlock"
@@ -67,6 +70,10 @@
 	unbolted = add_output_port("Unbolted", PORT_TYPE_SIGNAL)
 	user_port = add_output_port("User", PORT_TYPE_ATOM)
 	trigger_port = add_output_port("Triggered", PORT_TYPE_SIGNAL)
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		var/area/shuttle/AS = A
+		req_ship_access = AS.mobile_port?.id
 
 /obj/item/circuit_component/airlock/Destroy()
 	bolt = null

--- a/tgui/packages/tgui/interfaces/NtosCard.js
+++ b/tgui/packages/tgui/interfaces/NtosCard.js
@@ -29,6 +29,7 @@ export const NtosCardContent = (props, context) => {
     have_printer,
     have_id_slot,
     id_name,
+    ship,
   } = data;
   const [
     selectedDepartment,
@@ -69,6 +70,12 @@ export const NtosCardContent = (props, context) => {
               onClick={() => {
                 act(authenticated ? 'PRG_logout' : 'PRG_authenticate');
               }} />
+            <Button
+              icon="shuttle-space"
+              content="Set ship"
+              disabled={!ship || !has_id}
+              onClick={() => act('PRG_setship')}
+            />
           </>
         )}>
         <Button

--- a/tgui/packages/tgui/interfaces/NtosCard.js
+++ b/tgui/packages/tgui/interfaces/NtosCard.js
@@ -71,7 +71,7 @@ export const NtosCardContent = (props, context) => {
                 act(authenticated ? 'PRG_logout' : 'PRG_authenticate');
               }} />
             <Button
-              icon="shuttle-space"
+              icon="rocket"
               content="Set ship"
               disabled={!ship || !has_id}
               onClick={() => act('PRG_setship')}

--- a/tgui/packages/tgui/interfaces/ScannerGate.js
+++ b/tgui/packages/tgui/interfaces/ScannerGate.js
@@ -117,6 +117,10 @@ const SCANNER_GATE_ROUTES = {
     title: 'Scanner Mode: Nanites',
     component: () => ScannerGateNanites,
   },
+  Ship: {
+    title: 'Scanner Mode: Ship',
+    component: () => ScannerGateShip,
+  },
 };
 
 const ScannerGateControl = (props, context) => {
@@ -322,6 +326,20 @@ const ScannerGateNanites = (props, context) => {
               })} />
           </LabeledList.Item>
         </LabeledList>
+      </Box>
+      <ScannerGateMode />
+    </>
+  );
+};
+
+const ScannerGateShip = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { reverse } = data;
+  return (
+    <>
+      <Box mb={2}>
+        Trigger if the person scanned {reverse ? 'is not' : 'is'}
+        {' '}a member of your ship.
       </Box>
       <ScannerGateMode />
     </>


### PR DESCRIPTION
Bullet point list of the features:
- Access to many things now requires the ship's access to use on top of their regular access.
- Ship access can be given to anyone by the captain using the ID mod program, effectively "recruiting" new crewmembers.
- Scanner gates can be configured to scan if someone has ship access.
- Objects that aren't on ships do not get this access lock, and can be accessed as normally.
- This compiled (I did not test it).

Short list of notable things that have ship access requirements:
 -Doors
 -Buttons
 -Robots
 -Airlock controllers
 -APCs
 -Air alarms
 -Emitters
 -Display cases
 -Lock boxes
 -Nav beacons
 -(secure) Closets
 -Keycard authenticators
 -Mass drivers