### PR TITLE
fixes examining on accessories

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -218,6 +218,22 @@
 
 			return "[output][and_text][input[index]]"
 
+//Same as english_list, but for html input
+/proc/html_english_list(list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
+	var/total = length(input)
+	switch(total)
+		if (0)
+			return "[nothing_text]"
+		if (1)
+			return "[input[1]]"
+		if (2)
+			return "[input[1]][and_text][input[2]]"
+		else
+			var/output = ""
+			for(var/i in 1 to total - 1)
+				output += "[input[i]][comma_text]"
+			return "[output][and_text][input[total]]"
+
 /// Return either pick(list) or null if list is not of type /list or is empty
 /proc/safepick(list/L)
 	if(LAZYLEN(L))

--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -2,13 +2,13 @@
 	/// If non-null, overrides a/an/some in all cases
 	var/article
 	/// Text that appears preceding the name in examine()
-	var/examine_thats = "That's"
+	var/examine_intro = "That's"
 
 /mob/living/carbon/human
-	examine_thats = "This is"
+	examine_intro = "This is"
 
 /mob/living/silicon/robot
-	examine_thats = "This is"
+	examine_intro = "This is"
 
 /**
  * Called when a mob examines (shift click or verb) this atom
@@ -174,7 +174,7 @@
  */
 /atom/proc/examine_title(mob/user, thats = FALSE)
 	var/examine_icon = get_examine_icon(user)
-	return "[examine_icon ? "[examine_icon] " : ""][thats ? "[examine_thats] ":""]<em>[get_examine_name(user)]</em>"
+	return "[examine_icon ? "[examine_icon] " : ""][thats ? "[examine_intro] ":""]<em>[get_examine_name(user)]</em>"
 
 /**
  * Returns an extended list of examine strings for any contained ID cards.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1649,15 +1649,28 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		usr.examinate(src)
 		return TRUE
 
+//So, a little word about our examine separation here. We need to be careful about whether the observer is examining the mob, or the item directly.
+//If they examine the mob, we obviously want to include the href link letting them look at said mob's worn items.
+//Conversely, if they are examining the item directly(like clicking on aforementioned href link), it will fuck our nice examine box up if it tries to put another href in the title(name) of the item.
+//SO!
+//Mob examines, skip_examine_link = FALSE. | Item examines, skip_examine_link = TRUE.
+//Obey this *carefully*.
+
+/*
+ * Our general proc for fusing together the examine_intro (Identifies *this*(what you are examining at)) and X(the subject)
+ * Use this for most to_chat() phrasing in examine(), unless you want to manipulate the phrasing specifically, in which, use get_examine_line() directly
+ */
 /obj/item/examine_title(mob/user, thats = FALSE)
 	// Items use get_examine_line() which includes blood stains, ID links, examine links, etc.
 	// When thats=TRUE, this is the main item being examined, so skip the self-referential examine link
 	// When thats=FALSE, this is an inventory item, so include the examine link
 	var/examine_line = get_examine_line(skip_examine_link = thats)
 	if(thats)
-		examine_line = "[examine_thats] [examine_line]"
+		examine_line = "[examine_intro] [examine_line]"
 	return examine_line
 
+//Builds the examine name string with examine link and/or ID link, if applicable.
+//skip_examine_link: If TRUE, will not add an examine link to the item
 /obj/item/proc/get_examine_line(skip_examine_link = FALSE)
 	var/whole_word = usr?.client?.prefs?.read_player_preference(/datum/preference/toggle/whole_word_examine_links)
 	var/examine_name = get_examine_name(usr)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -655,6 +655,39 @@ BLIND	 // can't see anything
 	if (!is_mining_level(T.z))
 		return . * high_pressure_multiplier
 
+
+/// Returns a string for the examine line, including visible accessories.
+/obj/item/clothing/under/get_examine_line(skip_examine_link = FALSE)
+	. = ..()
+	var/list/visible = get_visible_accessories(shortened = TRUE)
+	if(length(visible) && skip_examine_link == FALSE) //We use skip_examine_link to also hide unecessary accessory links (titles mostly)
+		var/list/display = list()
+		for (var/obj/item/clothing/accessory/A in visible)
+			if(!A.hidden && A.high_visibility)
+				display += "[icon2html(A, usr)] \a [A]"
+		if(length(display))
+			. += " with [english_list(display)] attached"
+		if(length(visible) > length(display))
+			. += ". <a href='byond://?src=\ref[src];list_accessorize=1'>\[See accessories\]</a>"
+
+//This has been refactored to support accessories on different clothing items. At the moment its hardcoded for clothing/under, but should support expansion for Suits and Hats.
+//To do so, we just need to move attached_accessories list to /obj/item/clothing
+/obj/item/clothing/under/proc/get_visible_accessories(shortened = TRUE)
+	var/list/result = list()
+	if (!isnull(attached_accessories))
+		for (var/accessory_slot in attached_accessories)
+			var/obj/item/clothing/accessory/accessory = attached_accessories[accessory_slot]
+			// Hidden accessories do not show
+			if (!accessory || accessory.hidden)
+				continue
+			// Accessories that are below a suit hiding them do not show
+			if (!accessory.above_suit && ishuman(loc))
+				var/mob/living/carbon/human/H = loc
+				if (H.wear_suit && (H.wear_suit.body_parts_covered & accessory.attachment_slot))
+					continue
+			result += accessory
+	return result
+
 #undef SENSORS_OFF
 #undef SENSORS_BINARY
 #undef SENSORS_VITALS

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -25,6 +25,18 @@
 	bio = 10
 	bleed = 10
 
+/obj/item/clothing/under/Topic(href, href_list)
+	. = ..()
+
+	if(href_list["list_accessorize"])
+		var/list/visible = get_visible_accessories(shortened = FALSE)
+		if (length(visible))
+			var/list/display = list()
+			for (var/obj/item/clothing/accessory/A in visible)
+				if (!(A.hidden))
+					display += "[icon2html(A, usr)] \a [A]<a href='byond://?src=\ref[A];examine=1'>\[?\]</a>"
+			to_chat(usr, "Attached to \the [src] are [english_list(display)].")
+
 /obj/item/clothing/under/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file, item_layer, atom/origin)
 	. = list()
 	if(!isinhands)
@@ -311,6 +323,7 @@
 				. += "Its vital tracker and tracking beacon appear to be enabled."
 	for (var/accessory_slot in attached_accessories)
 		var/obj/item/clothing/accessory/accessory = attached_accessories[accessory_slot]
+		//Not necessary to nest 3 times with get_examine_line() here to examine the accessory lmao, just give its name
 		. += "\A [accessory] is attached to it's [LOWER_TEXT(accessory_slot)]."
 
 /obj/item/clothing/under/verb/toggle()

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -35,7 +35,7 @@
 			for (var/obj/item/clothing/accessory/A in visible)
 				if (!(A.hidden))
 					display += "[icon2html(A, usr)] \a [A]<a href='byond://?src=\ref[A];examine=1'>\[?\]</a>"
-			to_chat(usr, "Attached to \the [src] are [english_list(display)].")
+			to_chat(usr, examine_block("Attached to \the [src] are [html_english_list(display)]."), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
 
 /obj/item/clothing/under/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file, item_layer, atom/origin)
 	. = list()

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -14,6 +14,8 @@
 	var/accessory_slot = ACCESSORY_CHEST
 	/// Is this accessory hidden to examiners?
 	var/hidden = FALSE
+	/// Should this accessory appear to examiners without detailed view?
+	var/high_visibility = FALSE
 	/// Does it show above the armour slot item
 	var/above_suit = FALSE
 	/// TRUE if shown as a small icon in corner, FALSE if overlayed
@@ -89,6 +91,7 @@
 	desc = "For some classy, murderous fun."
 	icon_state = "waistcoat"
 	inhand_icon_state = "waistcoat"
+	high_visibility = TRUE
 	minimize_when_attached = FALSE
 	attachment_slot = null
 
@@ -97,6 +100,7 @@
 	desc = "The best part of a maid costume."
 	icon_state = "maidapron"
 	inhand_icon_state = "maidapron"
+	high_visibility = TRUE
 	minimize_when_attached = FALSE
 	attachment_slot = null
 
@@ -110,6 +114,7 @@
 	icon_state = "bronze"
 	custom_materials = list(/datum/material/iron=1000)
 	resistance_flags = FIRE_PROOF
+	high_visibility = TRUE
 	accessory_slot = ACCESSORY_MEDAL
 	accessory_layer = ACCESSORY_LAYER_MEDAL
 	var/medaltype = "medal" //Sprite used for medalbox
@@ -263,6 +268,7 @@
 	name = "red armband"
 	desc = "A fancy red armband!"
 	icon_state = "redband"
+	high_visibility = TRUE
 	attachment_slot = null
 	accessory_slot = ACCESSORY_ARMBAND
 	accessory_layer = ACCESSORY_LAYER_ARMBAND
@@ -410,6 +416,8 @@
 	inhand_icon_state = "holster"
 	worn_icon_state = "holster"
 	slot_flags = ITEM_SLOT_SUITSTORE|ITEM_SLOT_BELT
+	//Unsure about this one. Maybe not visible if wearing a jacket?
+	high_visibility = TRUE
 	var/holstertype = /datum/storage/pockets/holster
 
 /obj/item/clothing/accessory/holster/Initialize(mapload)
@@ -448,6 +456,7 @@
 	icon_state = "officerbadge"
 	worn_icon_state = "officerbadge"
 	w_class = WEIGHT_CLASS_TINY
+	high_visibility = TRUE
 	accessory_slot = ACCESSORY_MEDAL
 	accessory_layer = ACCESSORY_LAYER_MEDAL
 	above_suit = TRUE

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -326,7 +326,8 @@
 
 	//uniform
 	if(w_uniform && !(obscured & ITEM_SLOT_ICLOTHING) && !HAS_TRAIT(w_uniform, TRAIT_EXAMINE_SKIP))
-		//accessory
+		/*
+		//accessory (this should really be genericized to all clothing, not just under-uniforms)
 		var/accessory_message = ""
 		if(istype(w_uniform, /obj/item/clothing/under))
 			var/obj/item/clothing/under/undershirt = w_uniform
@@ -342,8 +343,9 @@
 				accessories += "[icon2html(accessory, user)] \a [accessory]"
 			if (length(accessories))
 				accessory_message += " with [english_list(accessories)]"
+		*/
 
-		. += "[t_He] [t_is] wearing [w_uniform.examine_title(user)][accessory_message]."
+		. += "[t_He] [t_is] wearing [w_uniform.get_examine_line(skip_examine_link = FALSE)]."
 	//head
 	if(head && !(obscured & ITEM_SLOT_HEAD) && !HAS_TRAIT(head, TRAIT_EXAMINE_SKIP))
 		. += "[t_He] [t_is] wearing [head.examine_title(user)] on [t_his] head."

--- a/code/modules/security/security_pager.dm
+++ b/code/modules/security/security_pager.dm
@@ -2,6 +2,7 @@
 	name = "security pager"
 	desc = "A chest-mounted pager which is used to quickly keep in touch with a commanding body."
 	icon_state = "pager"
+	high_visibility = TRUE
 	above_suit = TRUE
 	var/obj/item/radio/radio
 	COOLDOWN_DECLARE(deathgasp_cooldown)


### PR DESCRIPTION
Fixes accessory examination.

The game will try to always show accessories. However if an accessory is added that doesnt have high_visibility = TRUE, it will not be visible on mob examine, and the [[See accessories]](byond://?src=[0x2027dc9];list_accessorize=1) will show up.

<img width="374" height="227" alt="image" src="https://github.com/user-attachments/assets/f9ea5882-a10a-4bd8-bf55-5114030485cb" />

.

<img width="377" height="225" alt="image" src="https://github.com/user-attachments/assets/7a33fb22-77c1-4cc4-9ff0-74816244064e" />


